### PR TITLE
prerequisites using archetypes link

### DIFF
--- a/archetypes/gwtp-appengine-objectify/README.md
+++ b/archetypes/gwtp-appengine-objectify/README.md
@@ -9,6 +9,8 @@ GWTP using AppEngine with Objectify, RPC dispatch and Google Login.
 
 ##Maven Archetype Usage
 
+Since this archetype isn't in maven central, there are [prerequisites before using it](https://github.com/ArcBees/ArcBees-tools/wiki/archetype).
+
 1. Goto directory you want the project.
 2. Rename parameter below `com.projectname.project` to a package naming scheme you like.
 3. Rename parameter `new-project-name` to a project title you like.


### PR DESCRIPTION
Just added a link for greater clarity in the readme which at least stumped people like me, who are not used to using archetypes outside of maven central.
