### PR TITLE
Fixes to broken project

### DIFF
--- a/archetypes/gwtp-appengine-guice/pom.xml
+++ b/archetypes/gwtp-appengine-guice/pom.xml
@@ -14,6 +14,10 @@
     <name>gwtp-appengine-guice-archetype</name>
     <description>GWTP Appengine Guice application</description>
 
+    <properties>
+        <gwtp-default-version>1.6-SNAPSHOT</gwtp-default-version>
+    </properties>
+
     <build>
         <extensions>
             <extension>

--- a/archetypes/gwtp-appengine-guice/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/gwtp-appengine-guice/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -6,6 +6,9 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <requiredProperties>
         <requiredProperty key="moduleName"/>
+        <requiredProperty key="gwtp-version">
+            <defaultValue>${gwtp-default-version}</defaultValue>
+        </requiredProperty>
     </requiredProperties>
 
     <fileSets>

--- a/archetypes/gwtp-appengine-guice/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/gwtp-appengine-guice/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <!-- client -->
         <gwt.version>2.7.0</gwt.version>
-        <gwtp.version>1.4</gwtp.version>
+        <gwtp.version>${gwtp-version}</gwtp.version>
         <gin.version>2.1.2</gin.version>
         <gwt.style>OBF</gwt.style>
 

--- a/archetypes/gwtp-basic/pom.xml
+++ b/archetypes/gwtp-basic/pom.xml
@@ -14,6 +14,10 @@
     <name>gwtp-basic-archetype</name>
     <description>Basic GWTP application</description>
 
+    <properties>
+        <gwtp-default-version>1.6-SNAPSHOT</gwtp-default-version>
+    </properties>
+
     <build>
         <extensions>
             <extension>

--- a/archetypes/gwtp-basic/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/gwtp-basic/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -6,6 +6,9 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <requiredProperties>
         <requiredProperty key="moduleName"/>
+        <requiredProperty key="gwtp-version">
+            <defaultValue>${gwtp-default-version}</defaultValue>
+        </requiredProperty>
     </requiredProperties>
 
     <fileSets>

--- a/archetypes/gwtp-basic/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/gwtp-basic/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <!-- client -->
         <gwt.version>2.7.0</gwt.version>
-        <gwtp.version>1.5.1</gwtp.version>
+        <gwtp.version>${gwtp-version}</gwtp.version>
         <gin.version>2.1.2</gin.version>
         <gwt.style>OBF</gwt.style>
 

--- a/archetypes/gwtp-basic/src/main/resources/archetype-resources/src/main/java/client/application/ApplicationView.java
+++ b/archetypes/gwtp-basic/src/main/resources/archetype-resources/src/main/java/client/application/ApplicationView.java
@@ -21,4 +21,5 @@ public class ApplicationView extends ViewImpl implements ApplicationPresenter.My
         initWidget(uiBinder.createAndBindUi(this));
 
         bindSlot(ApplicationPresenter.SLOT_MAIN, main);
+    }
 }


### PR DESCRIPTION
Hey, the archetypes are currently broken, i.e. the generated projects cannot be built due to the missing bracket. Second issue is that `gwtp-appengine-guice-archetype` has a hardcoded GWTP version 1.4 which breaks ApplicationPresenter (bad import since it's copied from `gwtp-basic-archetype` that's on 1.5.1). Do you need an issue for this?